### PR TITLE
Adding warmup/cooldown and output file

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,9 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-/.DS_Store

--- a/.idea/kafka-test.iml
+++ b/.idea/kafka-test.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
-    <output url="file://$PROJECT_DIR$/out" />
-  </component>
-</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/kafka-test.iml" filepath="$PROJECT_DIR$/.idea/kafka-test.iml" />
-    </modules>
-  </component>
-</project>

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -1,9 +1,14 @@
 {
     "topic1": "scrooge",
-    "topci2": "kafka-test",
+    "topic2": "kafka-test",
     "rsm_id": 1,
     "node_id": 1,
     "broker_ips": "10.138.8.184:9092, 10.138.8.184:9092, 10.138.8.184:9092",
+    "rsm_size": 3,
+    "read_from_pipe": true,
     "message": "helloo",
-    "rsm_size": 3
+    "benchmark_duration": 10,
+    "warmup_duration": 3,
+    "cooldown_duration": 3,
+    "output_path": "./"
 }

--- a/src/main/scala/configReader.scala
+++ b/src/main/scala/configReader.scala
@@ -36,12 +36,32 @@ class ConfigReader {
     configData("broker_ips").str
   }
 
+  def getRsmSize(): Double = {
+    configData("rsm_size").num
+  }
+
   def getMessage(): String = {
     configData("message").str
   }
 
-  def getRsmSize(): Double = {
-    configData("rsm_size").num
+  def shouldReadFromPipe(): Boolean = {
+    configData("read_from_pipe").bool
+  }
+
+  def getBenchmarkDuration(): Double = {
+    configData("benchmark_duration").num
+  }
+
+  def getWarmupDuration(): Double = {
+    configData("warmup_duration").num
+  }
+
+  def getCooldownDuration(): Double = {
+    configData("cooldown_duration").num
+  }
+
+  def getOutputPath(): String = {
+    configData("output_path").str
   }
 }
 

--- a/src/main/scala/consumer.scala
+++ b/src/main/scala/consumer.scala
@@ -46,7 +46,7 @@ object Consumer {
 
   def consumeFromKafka(timer: Deadline) = {
     val props = new Properties()
-    props.put("bootstrap.servers", "localhost:9092")
+    props.put("bootstrap.servers", brokerIps)
     props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer")
     props.put("auto.offset.reset", "latest")

--- a/src/main/scala/consumer.scala
+++ b/src/main/scala/consumer.scala
@@ -33,9 +33,9 @@ object Consumer {
     while (warmup.hasTimeLeft()) { } // Do nothing
 
     // Run a new thread to measure throughput -> an optimization since polling may take a bit of time
-    val timer = benchmarkDuration.seconds.fromNow
+    val benchmark = benchmarkDuration.seconds.fromNow
     val throughputMeasurement = Future {
-      consumeFromKafka(timer)
+      consumeFromKafka(benchmark)
     }
     Await.result(throughputMeasurement, Duration.Inf) // Wait on new thread to finish
 
@@ -46,12 +46,13 @@ object Consumer {
 
   def consumeFromKafka(timer: Deadline) = {
     val props = new Properties()
-    props.put("bootstrap.servers", brokerIps)
+    props.put("bootstrap.servers", "localhost:9092")
     props.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer")
     props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer")
     props.put("auto.offset.reset", "latest")
     props.put("group.id", "consumer-group")
     val consumer: KafkaConsumer[String, Array[Byte]] = new KafkaConsumer[String, Array[Byte]](props)
+    consumer.subscribe(util.Arrays.asList(topic))
 
     var messagesDeserialized = 0
     var startTime = System.currentTimeMillis()
@@ -83,6 +84,7 @@ object Consumer {
     }   
     consumer.close()
 
-    outputWriter.writeOutput(outputContent, outputPath)
+    println(outputContent)
+    outputWriter.writeOutput(outputContent, outputPath + "output.json")
   }
 }

--- a/src/main/scala/consumer.scala
+++ b/src/main/scala/consumer.scala
@@ -13,31 +13,35 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 object Consumer {
-
   val configReader = new ConfigReader
-
-  val brokerIps = configReader.getBrokerIps()
-  val nodeId = configReader.getNodeId()
   val rsmId = configReader.getRsmId()
+  val nodeId = configReader.getNodeId()
+  val topic = if (rsmId == 1) configReader.getTopic1() else configReader.getTopic2()
+  val brokerIps = configReader.getBrokerIps()
+  val rsmSize = configReader.getRsmSize()
+  val benchmarkDuration = configReader.getBenchmarkDuration()
+  val warmupDuration = configReader.getWarmupDuration()
+  val cooldownDuration = configReader.getCooldownDuration()
+  val outputPath = configReader.getOutputPath()
 
-  //rsm 1 reads from topic 2, rsm 2 reads from topic 1
-  val topic = 
-    if (rsmId == 1) {
-      configReader.getTopic1()
-    } else {
-      configReader.getTopic2()
-    }
+  val outputWriter = new OutputWriter
 
   def main(args: Array[String]): Unit = {
-    val timer = 10.seconds.fromNow
+
+    // Warmup period
+    val warmup = warmupDuration.seconds.fromNow
+    while (warmup.hasTimeLeft()) { } // Do nothing
 
     // Run a new thread to measure throughput -> an optimization since polling may take a bit of time
+    val timer = benchmarkDuration.seconds.fromNow
     val throughputMeasurement = Future {
       consumeFromKafka(timer)
     }
+    Await.result(throughputMeasurement, Duration.Inf) // Wait on new thread to finish
 
-    // Wait on new thread to finish
-    Await.result(throughputMeasurement, Duration.Inf)
+    // Cooldown period
+    val cooldown = cooldownDuration.seconds.fromNow
+    while (cooldown.hasTimeLeft()) { } // Do nothing
   }
 
   def consumeFromKafka(timer: Deadline) = {
@@ -51,6 +55,8 @@ object Consumer {
 
     var messagesDeserialized = 0
     var startTime = System.currentTimeMillis()
+
+    var outputContent = ""
 
     while (timer.hasTimeLeft()) {
       val record = consumer.poll(1000).asScala
@@ -69,11 +75,14 @@ object Consumer {
       val currentTime = System.currentTimeMillis()
       if (currentTime - startTime >= 1000) {
         val throughput = messagesDeserialized.toDouble / ((currentTime - startTime).toDouble / 1000)
-        println(s"Throughput: ${throughput} MPS")
+        outputContent += s"Throughput: ${throughput} MPS\n"
+
         messagesDeserialized = 0
         startTime = currentTime
       }
     }   
     consumer.close()
+
+    outputWriter.writeOutput(outputContent, outputPath)
   }
 }

--- a/src/main/scala/outputWriter.scala
+++ b/src/main/scala/outputWriter.scala
@@ -1,0 +1,28 @@
+package main
+
+import upickle.default._
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
+
+case class OutputFormat(content: String)
+
+/* Macro annotations used by upickle to generate Writer 
+ * at compile time. Allows object OutputFormat to be 
+ * implicitly availbel to upicke's write function
+*/
+object OutputFormat {
+  implicit val writer: Writer[OutputFormat] = macroW
+}
+
+class OutputWriter {
+
+  def writeOutput(content: String, path: String): Unit = {
+    val outputData = OutputFormat(content)
+
+    val json = write(outputData)
+
+    val outputPath = Paths.get(path)
+
+    Files.write(outputPath, json.getBytes(StandardCharsets.UTF_8))
+  }
+}

--- a/src/main/scala/producer.scala
+++ b/src/main/scala/producer.scala
@@ -48,7 +48,7 @@ object Producer {
 
   def writeToKafka(messageString: String, timer: Deadline): Unit = {
     val props = new Properties()
-    props.put("bootstrap.servers", "localhost:9092")
+    props.put("bootstrap.servers", brokerIps)
     props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
     props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer")
     val producer = new KafkaProducer[String, Array[Byte]](props)


### PR DESCRIPTION
Fixed producer code too. 

Before: For 10 seconds, create a producer object w/ IP configurations and serialize the message to send

Now: Create producer object first w/ IP configurations. For x (defined by the config.json) seconds, serialize the message and send

Result: Increase in message per second by ALOT
<img width="313" alt="image" src="https://github.com/chawinphat/scrooge-kafka/assets/59751754/cd316157-aec2-474a-99ff-6d235d0132b0">
